### PR TITLE
use sRGB colorspace by default

### DIFF
--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -3,6 +3,8 @@
 
 resolution=1024
 density=300
+#colorspace="-depth 8"
+colorspace="-colorspace sRGB -background white -alpha remove"
 makeWide=true
 
 if [ $# -eq 0 ]; then
@@ -28,7 +30,7 @@ if [ -d $tempname ]; then
 fi
 
 mkdir $tempname
-convert -density $density -depth 8 -resize "x${resolution}" $1 ./$tempname/slide.png
+convert -density $density $colorspace -resize "x${resolution}" $1 ./$tempname/slide.png
 
 if [ $? -eq 0 ]; then
 	echo "Extraction succ!"


### PR DESCRIPTION
Thanks for this very useful tool. Had issues with images getting distorted, figured out it is due to the colorspace and powerpoint always using sRGB. 

Unfortunally the files geht bigger with this, but the colors are better.

PS: I also switched to using 600 DPI for conversation, the quality gets much better and it hardly affects the final file size in my case. However had to increase limits in /etc/ImageMagick-6/policy.xml