### PR TITLE
Loose restrictions of paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This script gets a PDF file as input and generates a Powerpoint PPTX file while 
 Simply explained, I convert all the slides to high-quality image files first, and then push them into a Powerpoint project as a slide.
 
 # How to run
-* Copy your pdf file next to the script first.
 * Execute `./pdf2pptx.sh test.pdf` to generate a `test.pdf.pptx` file  (replace `test.pdf` with your filename).
 * By default the output powerpoint project is in the widescreen mode. If your slides are not for widescreen you can alternatively run `./pdf2pptx.sh test.pdf notwide` to generate a 4:3 standard PPTX project.
 
 # Dependencies
 * You need `convert` from [ImageMagick] (http://www.imagemagick.org/script/binary-releases.php)
 * `zip` and `sed`
+* (Optional) `perl`, `python`, or `ruby` if you use a symlink to pdf2pptx.sh
 
 If you're using *Linux* you *probably* already have all the above.
 

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -30,7 +30,7 @@ if [ -d "$tempname" ]; then
 fi
 
 mkdir "$tempname"
-convert -density $density $colorspace -resize "x${resolution}" "$1" ./"$tempname"/slide.png
+convert -density $density $colorspace -resize "x${resolution}" "$1" "$tempname"/slide.png
 
 if [ $? -eq 0 ]; then
 	echo "Extraction succ!"
@@ -40,13 +40,13 @@ else
 fi
 
 pptname="$1.pptx.base"
-fout="$1.pptx"
+fout=$(basename "$1.pptx")
 rm -rf "$pptname"
 cp -r $(dirname "$0")/template "$pptname"
 
 mkdir "$pptname"/ppt/media
 
-cp ./"$tempname"/*.png "$pptname/ppt/media/"
+cp "$tempname"/*.png "$pptname/ppt/media/"
 
 function call_sed {
 	if [ "$(uname -s)" == "Darwin" ]; then

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -42,7 +42,7 @@ fi
 pptname="$1.pptx.base"
 fout="$1.pptx"
 rm -rf "$pptname"
-cp -r template "$pptname"
+cp -r $(dirname "$0")/template "$pptname"
 
 mkdir "$pptname"/ppt/media
 

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -24,13 +24,13 @@ fi
 
 echo "Doing $1"
 tempname="$1.temp"
-if [ -d $tempname ]; then
+if [ -d "$tempname" ]; then
 	echo "Removing ${tempname}"
-	rm -rf $tempname
+	rm -rf "$tempname"
 fi
 
-mkdir $tempname
-convert -density $density $colorspace -resize "x${resolution}" $1 ./$tempname/slide.png
+mkdir "$tempname"
+convert -density $density $colorspace -resize "x${resolution}" "$1" ./"$tempname"/slide.png
 
 if [ $? -eq 0 ]; then
 	echo "Extraction succ!"
@@ -41,12 +41,12 @@ fi
 
 pptname="$1.pptx.base"
 fout="$1.pptx"
-rm -rf $pptname
-cp -r template $pptname
+rm -rf "$pptname"
+cp -r template "$pptname"
 
-mkdir $pptname/ppt/media
+mkdir "$pptname"/ppt/media
 
-cp ./$tempname/*.png "$pptname/ppt/media/"
+cp ./"$tempname"/*.png "$pptname/ppt/media/"
 
 function call_sed {
 	if [ "$(uname -s)" == "Darwin" ]; then
@@ -83,7 +83,7 @@ function make_slide {
 	add_slide $1
 }
 
-pushd $pptname/ppt/media/
+pushd "$pptname"/ppt/media/
 count=`ls -ltr | wc -l`
 for (( slide=$count-2; slide>=0; slide-- ))
 do
@@ -98,10 +98,10 @@ if [ "$makeWide" = true ]; then
 fi
 popd
 
-pushd $pptname
-rm -rf ../$fout
-zip -q -r ../$fout .
+pushd "$pptname"
+rm -rf ../"$fout"
+zip -q -r ../"$fout" .
 popd
 
-rm -rf $pptname
-rm -rf $tempname
+rm -rf "$pptname"
+rm -rf "$tempname"

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -39,10 +39,23 @@ else
 	exit
 fi
 
+if (which perl > /dev/null); then
+	# https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#comment47931362_1115074
+	mypath=$(perl -MCwd=abs_path -le 'print abs_path readlink(shift);' "$0")
+elif (which python > /dev/null); then
+	# https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#comment42284854_1115074
+	mypath=$(python -c 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' "$0")
+elif (which ruby > /dev/null); then
+	mypath=$(ruby -e 'puts File.realpath(ARGV[0])' "$0")
+else
+	mypath="$0"
+fi
+mydir=$(dirname "$mypath")
+
 pptname="$1.pptx.base"
 fout=$(basename "$1.pptx")
 rm -rf "$pptname"
-cp -r $(dirname "$0")/template "$pptname"
+cp -r "$mydir"/template "$pptname"
 
 mkdir "$pptname"/ppt/media
 


### PR DESCRIPTION
This PR is a collection of several simple commits. The first one is important for security.

* Support white spaces in file names for safety.
* Make pdf2pptx.sh callable from anywhere.
* Accept files outside the current directory.
* Symlinks to pdf2pptx.sh also work now.

In the last feature, I use perl, python, or ruby to get the real path of a symlink because they are much simpler than pure shellscript implementations. You can still use pdf2pptx.sh without perl/python/ruby as long as you use not a symlink but the real pdf2pptx.sh itself.
