### PR TITLE
Fix perl line to get absolute path

### DIFF
--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -41,7 +41,7 @@ fi
 
 if (which perl > /dev/null); then
 	# https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#comment47931362_1115074
-	mypath=$(perl -MCwd=abs_path -le 'print abs_path readlink(shift);' "$0")
+	mypath=$(perl -MCwd=abs_path -le '$file=shift; print abs_path -l $file? readlink($file): $file;' "$0")
 elif (which python > /dev/null); then
 	# https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#comment42284854_1115074
 	mypath=$(python -c 'import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' "$0")


### PR DESCRIPTION
There seems a problem to run `./pdf2pptx.sh test.pdf` in the environment where `perl` is installed.
When `pdf2pptx.sh` is not specified by symlink, the line of `perl` generates an absolute path without the file name as `readlink(shift)` returns an empty string.

The updated line first checks if `$0` is symlink. If it is not a symlink, it avoids calling the `readlink` function.