### PR TITLE
Improve converted pptx file size using JPG quality

### DIFF
--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -30,7 +30,7 @@ if [ -d "$tempname" ]; then
 fi
 
 mkdir "$tempname"
-convert -density $density $colorspace -resize "x${resolution}" "$1" "$tempname"/slide.png
+convert -density $density $colorspace -quality 75 -resize "x${resolution}" "$1" "$tempname"/slide.jpg
 
 if [ $? -eq 0 ]; then
 	echo "Extraction succ!"
@@ -59,7 +59,7 @@ cp -r "$mydir"/template "$pptname"
 
 mkdir "$pptname"/ppt/media
 
-cp "$tempname"/*.png "$pptname/ppt/media/"
+cp "$tempname"/*.jpg "$pptname/ppt/media/"
 
 function call_sed {
 	if [ "$(uname -s)" == "Darwin" ]; then
@@ -92,7 +92,7 @@ function add_slide {
 
 function make_slide {
 	cp ../slides/slide1.xml ../slides/slide-$1.xml
-	cat ../slides/_rels/slide1.xml.rels | sed "s/image1\.JPG/slide-${slide}.png/g" > ../slides/_rels/slide-$1.xml.rels
+	cat ../slides/_rels/slide1.xml.rels | sed "s/image1\.JPG/slide-${slide}.jpg/g" > ../slides/_rels/slide-$1.xml.rels
 	add_slide $1
 }
 


### PR DESCRIPTION
Hi. 

First, great software, thank you. 
I had a challenge convert an 10 MBytes files PDF, from an original PPTX of 165MBytes.
This PPTX file was to large to be imported on Google Presentation. I don't have any tools capable to handle this PPTX. The solution was to convert the 10MB pdf to images and create a new PPTX. Found your software, that does exactly what I need to this task.
Initially the conversion from 165MBytes was resulting in a file of 130MB a good start. Looking into the source, I could see the PNG conversion from every slide inside the PDF. So I tried to tackle the PNG quality problem, that is not a simple problem. Not very fan of JPG, but its simpler to manage its quality using the flag "-quality". Tried this new approach resulting in a file size PPTX of 10MB.
Tried to import this new PPTX to Google Presentation, success! The presentation works without problems, like the PDF. In this specific case I couldn't notice problems with the image quality. I would like to share with you my results but this material is not my mine (proprietary). 

The objective of this pull request is:

- Change PNG to JPG, because JPG offers better control to compression
  using convert.

I hope this could improve your software.
Thanks.