### PR TITLE
using pdftoppm from  poppler instead of ImageMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Simply explained, I convert all the slides to high-quality image files first, an
 * By default the output powerpoint project is in the widescreen mode. If your slides are not for widescreen you can alternatively run `./pdf2pptx.sh test.pdf notwide` to generate a 4:3 standard PPTX project.
 
 # Dependencies
-* You need `convert` from [ImageMagick] (http://www.imagemagick.org/script/binary-releases.php)
+* you need :
+** `convert` from [ImageMagick] (http://www.imagemagick.org/script/binary-releases.php)
+** `pdftoppm` from [poppler](https://cgit.freedesktop.org/poppler/poppler)
+*** debian : apt-get install poppler-utils
+*** archlinux : pacman -S poppler
 * `zip` and `sed`
 * (Optional) `perl`, `python`, or `ruby` if you use a symlink to pdf2pptx.sh
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Simply explained, I convert all the slides to high-quality image files first, an
 # How to run
 * Execute `./pdf2pptx.sh test.pdf` to generate a `test.pdf.pptx` file  (replace `test.pdf` with your filename).
 * By default the output powerpoint project is in the widescreen mode. If your slides are not for widescreen you can alternatively run `./pdf2pptx.sh test.pdf notwide` to generate a 4:3 standard PPTX project.
+* Runing with poppler : `./pdf2pptx-pdftoppm.sh test.pdf`
 
 # Dependencies
 * you need :


### PR DESCRIPTION
Hello,
I had a problem with the security from ImageMagicks. I had to use pdftoppm instead.
I don't know if you are interested by this other solution.

On the modification part, I had to change the way slide number are generated since pdftoppm generate the number with more than one digit.
As a result I added one argument to `add_slide`. The first one is the number with the right amount of digits. the second argument is for the Id.

Thank  you for your work.