### PR TITLE
Support spaces in filenames

### DIFF
--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -53,7 +53,7 @@ fi
 mydir=$(dirname "$mypath")
 
 pptname="$1.pptx.base"
-fout=$(basename $1 .pdf)".pptx"
+fout=$(basename "$1" .pdf)".pptx"
 rm -rf "$pptname"
 cp -r "$mydir"/template "$pptname"
 


### PR DESCRIPTION
We need to use `"$1"` instead of `$1` to support spaces in filenames.