### PR TITLE
Convert PDF pages separately

### DIFF
--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -30,7 +30,11 @@ if [ -d "$tempname" ]; then
 fi
 
 mkdir "$tempname"
-convert -density $density $colorspace -resize "x${resolution}" "$1" "$tempname"/slide.png
+n_pages=$(pdfinfo "$1" | grep Pages | awk '{print $2}')
+for ((i=0; i<n_pages; i++))
+do
+    convert -density $density $colorspace -resize "x${resolution}" "$1[$i]" "$tempname"/slide-$i.png
+done
 
 if [ $? -eq 0 ]; then
 	echo "Extraction succ!"

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -34,13 +34,15 @@ n_pages=$(pdfinfo "$1" | grep Pages | awk '{print $2}')
 for ((i=0; i<n_pages; i++))
 do
     convert -density $density $colorspace -resize "x${resolution}" "$1[$i]" "$tempname"/slide-$i.png
+    returncode=$?
+    if [ $returncode -ne 0 ]; then break; fi
 done
 
-if [ $? -eq 0 ]; then
+if [ $returncode -eq 0 ]; then
 	echo "Extraction succ!"
 else
 	echo "Error with extraction"
-	exit
+	exit $returncode
 fi
 
 if (which perl > /dev/null); then

--- a/pdf2pptx.sh
+++ b/pdf2pptx.sh
@@ -30,7 +30,20 @@ if [ -d "$tempname" ]; then
 fi
 
 mkdir "$tempname"
-n_pages=$(pdfinfo "$1" | grep Pages | awk '{print $2}')
+
+# Set return code of piped command to first nonzero return code
+set -o pipefail
+n_pages=$(identify "$1" | wc -l)
+returncode=$?
+if [ $returncode -ne 0 ]; then
+   echo "Unable to count number of PDF pages, exiting"
+   exit $returncode
+fi
+if [ $n_pages -eq 0 ]; then
+   echo "Empty PDF (0 pages), exiting"
+   exit 1
+fi
+
 for ((i=0; i<n_pages; i++))
 do
     convert -density $density $colorspace -resize "x${resolution}" "$1[$i]" "$tempname"/slide-$i.png


### PR DESCRIPTION
For large PDF files, `convert` runs into memory issues, giving error message such as
```
convert-im6.q16: cache resources exhausted `talk.pdf' @ error/cache.c/OpenPixelCache/4083.
convert-im6.q16: cache resources exhausted `slide.png' @ error/cache.c/OpenPixelCache/4083.
convert-im6.q16: memory allocation failed `slide.png' @ error/png.c/WriteOnePNGImage/9108.
convert-im6.q16: No IDATs written into file `slide-0.png' @ error/png.c/MagickPNGErrorHandler/1641.
```
This pull request therefore proposes to do the conversion page-by-page, avoiding these issues.